### PR TITLE
Update run.bash

### DIFF
--- a/docker/run.bash
+++ b/docker/run.bash
@@ -12,7 +12,7 @@ then
     chmod a+r $XAUTH
 fi
 
-docker run --rm -it \
+docker run --net=host --rm -it \
         -v=/tmp/.X11-unix:/tmp/.X11-unix:rw \
         -v=${XAUTH}:${XAUTH}:rw \
         -e="XAUTHORITY=${XAUTH}" \


### PR DESCRIPTION
otherwise i get the below error on ubuntu 22
```
qt.qpa.xcb: could not connect to display :1
qt.qpa.plugin: Could not load the Qt platform plugin "xcb" in "" even though it was found.
This application failed to start because no Qt platform plugin could be initialized. Reinstalling the application may fix this problem.
```